### PR TITLE
first pass at using ticker over handrolled timing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,7 +128,8 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-#vscode folder
+#ide folders
 /.vscode
+.idea
 
 out/

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.15
 
 require (
 	github.com/gammazero/deque v0.0.0-20201010052221-3932da5530cc
+	github.com/magefile/mage v1.11.0 // indirect
 	github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0
-	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
+	github.com/sirupsen/logrus v1.8.0
+	golang.org/x/sys v0.0.0-20210227040730-b0d1d43c014d // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,17 @@
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gammazero/deque v0.0.0-20201010052221-3932da5530cc h1:F7BbnLACph7UYiz9ZHi6npcROwKaZUyviDjsNERsoMM=
 github.com/gammazero/deque v0.0.0-20201010052221-3932da5530cc/go.mod h1:IlBLfYXnuw9sspy1XS6ctu5exGb6WHGKQsyo4s7bOEA=
+github.com/magefile/mage v1.10.0 h1:3HiXzCUY12kh9bIuyXShaVe529fJfyqoVM42o/uom2g=
+github.com/magefile/mage v1.10.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
+github.com/magefile/mage v1.11.0 h1:C/55Ywp9BpgVVclD3lRnSYCwXTYxmSppIgLeDYlNuls=
+github.com/magefile/mage v1.11.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0 h1:LiZB1h0GIcudcDci2bxbqI6DXV8bF8POAnArqvRrIyw=
 github.com/olekukonko/ts v0.0.0-20171002115256-78ecb04241c0/go.mod h1:F/7q8/HZz+TXjlsoZQQKVYvXTZaFH4QRa3y+j1p7MS0=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.8.0 h1:nfhvjKcUMhBMVqbKHJlk5RPrrfYr/NMo3692g0dwfWU=
+github.com/sirupsen/logrus v1.8.0/go.mod h1:4GuYW9TZmE769R5STWrRakJc4UqQ3+QQ95fyz7ENv1A=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210227040730-b0d1d43c014d h1:9fH9JvLNoSpsDWcXJ4dSE3lZW99Z3OCUZLr07g60U6o=
+golang.org/x/sys v0.0.0-20210227040730-b0d1d43c014d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Hey @ap-pauloafonso, 

This is what I had in mind for trying to use a ticker instead of manually increment ints and channels. I _think_ this will work. But I have not run locally yet. Take a look and let me know what you think.

I added `logrus` for some prettier logging. Some of the log levels may be off, I just took my best guess.

Also, I always work with `golangci-lint` enabled in my IDE. So I patched up linter failures as I came across them. These changes are mostly to make sure errors are not ignored. 