### PR TITLE
callback instead of channel

### DIFF
--- a/internal/bencode/bencode_test.go
+++ b/internal/bencode/bencode_test.go
@@ -1,8 +1,8 @@
 package bencode
 
 import (
-	"io/ioutil"
 	"log"
+	"os"
 	"reflect"
 	"testing"
 )
@@ -99,13 +99,13 @@ func TestMapParse(T *testing.T) {
 
 func TestDecode(T *testing.T) {
 
-	files, err := ioutil.ReadDir("./torrent_files_test")
+	files, err := os.ReadDir("./torrent_files_test")
 	if err != nil {
 		log.Fatal(err)
 	}
 	for _, f := range files {
 		T.Run(f.Name(), func(t *testing.T) {
-			data, _ := ioutil.ReadFile("./torrent_files_test/" + f.Name())
+			data, _ := os.ReadFile("./torrent_files_test/" + f.Name())
 			result, _ := Decode(data)
 			t.Log(result["info"].(map[string]interface{})["name"])
 		})

--- a/internal/emulation/emulation.go
+++ b/internal/emulation/emulation.go
@@ -3,7 +3,7 @@ package emulation
 import (
 	"embed"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 
 	"github.com/ap-pauloafonso/ratio-spoof/internal/generator"
 )
@@ -83,7 +83,7 @@ func extractClient(code string) (*ClientInfo, error) {
 	}
 	defer f.Close()
 
-	bytes, err := ioutil.ReadAll(f)
+	bytes, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/generator/rounding_test.go
+++ b/internal/generator/rounding_test.go
@@ -2,7 +2,7 @@ package generator
 
 import "testing"
 
-func TestNextAmountReport(t *testing.T) {
+func TestDefaultRounding(t *testing.T) {
 	r, _ := NewDefaultRoudingGenerator()
 
 	d, u, l := r.Round(656497856, 46479878, 7879879, 1024)

--- a/internal/ratiospoof/ratiospoof.go
+++ b/internal/ratiospoof/ratiospoof.go
@@ -132,7 +132,6 @@ func (R *RatioSpoof) updateInterval(interval int) {
 	} else {
 		R.AnnounceInterval = 1800
 	}
-	R.AnnounceInterval = 30
 	R.updateEstimatedTimeToAnnounce(R.AnnounceInterval)
 }
 

--- a/internal/ratiospoof/ratiospoof.go
+++ b/internal/ratiospoof/ratiospoof.go
@@ -3,13 +3,11 @@ package ratiospoof
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
 	"os/signal"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -25,21 +23,19 @@ const (
 )
 
 type RatioSpoof struct {
-	mutex                           *sync.Mutex
-	TorrentInfo                     *bencode.TorrentInfo
-	Input                           *input.InputParsed
-	Tracker                         *tracker.HttpTracker
-	BitTorrentClient                *emulation.Emulation
-	AnnounceInterval                int
-	EstimatedTimeToAnnounce         time.Time
-	EstimatedTimeToAnnounceUpdateCh chan int
-	NumWant                         int
-	Seeders                         int
-	Leechers                        int
-	AnnounceCount                   int
-	Status                          string
-	AnnounceHistory                 announceHistory
-	StopPrintCH                     chan interface{}
+	TorrentInfo             *bencode.TorrentInfo
+	Input                   *input.InputParsed
+	Tracker                 *tracker.HttpTracker
+	BitTorrentClient        *emulation.Emulation
+	AnnounceInterval        int
+	EstimatedTimeToAnnounce time.Time
+	NumWant                 int
+	Seeders                 int
+	Leechers                int
+	AnnounceCount           int
+	Status                  string
+	AnnounceHistory         announceHistory
+	StopPrintCH             chan interface{}
 }
 
 type AnnounceEntry struct {
@@ -55,9 +51,8 @@ type announceHistory struct {
 }
 
 func NewRatioSpoofState(input input.InputArgs) (*RatioSpoof, error) {
-	EstimatedTimeToAnnounceUpdateCh := make(chan int)
 	stopPrintCh := make(chan interface{})
-	dat, err := ioutil.ReadFile(input.TorrentPath)
+	dat, err := os.ReadFile(input.TorrentPath)
 	if err != nil {
 		return nil, err
 	}
@@ -83,15 +78,13 @@ func NewRatioSpoofState(input input.InputArgs) (*RatioSpoof, error) {
 	}
 
 	return &RatioSpoof{
-		BitTorrentClient:                client,
-		TorrentInfo:                     torrentInfo,
-		Tracker:                         httpTracker,
-		Input:                           inputParsed,
-		NumWant:                         200,
-		Status:                          "started",
-		mutex:                           &sync.Mutex{},
-		StopPrintCH:                     stopPrintCh,
-		EstimatedTimeToAnnounceUpdateCh: EstimatedTimeToAnnounceUpdateCh,
+		BitTorrentClient: client,
+		TorrentInfo:      torrentInfo,
+		Tracker:          httpTracker,
+		Input:            inputParsed,
+		NumWant:          200,
+		Status:           "started",
+		StopPrintCH:      stopPrintCh,
 	}, nil
 }
 
@@ -117,7 +110,6 @@ func (R *RatioSpoof) Run() {
 
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	R.firstAnnounce()
-	go R.updateEstimatedTimeToAnnounceListener()
 	go func() {
 		for {
 			R.generateNextAnnounce()
@@ -140,20 +132,12 @@ func (R *RatioSpoof) updateInterval(interval int) {
 	} else {
 		R.AnnounceInterval = 1800
 	}
+	R.AnnounceInterval = 30
 	R.updateEstimatedTimeToAnnounce(R.AnnounceInterval)
 }
 
 func (R *RatioSpoof) updateEstimatedTimeToAnnounce(interval int) {
-	R.mutex.Lock()
-	defer R.mutex.Unlock()
 	R.EstimatedTimeToAnnounce = time.Now().Add(time.Duration(interval) * time.Second)
-}
-
-func (R *RatioSpoof) updateEstimatedTimeToAnnounceListener() {
-	for {
-		interval := <-R.EstimatedTimeToAnnounceUpdateCh
-		R.updateEstimatedTimeToAnnounce(interval)
-	}
 }
 
 func (R *RatioSpoof) updateSeedersAndLeechers(resp tracker.TrackerResponse) {
@@ -176,7 +160,7 @@ func (R *RatioSpoof) fireAnnounce(retry bool) error {
 		"{event}", R.Status,
 		"{numwant}", fmt.Sprint(R.NumWant))
 	query := replacer.Replace(R.BitTorrentClient.Query)
-	trackerResp, err := R.Tracker.Announce(query, R.BitTorrentClient.Headers, retry, R.EstimatedTimeToAnnounceUpdateCh)
+	trackerResp, err := R.Tracker.Announce(query, R.BitTorrentClient.Headers, retry, R.updateEstimatedTimeToAnnounce)
 	if err != nil {
 		log.Fatalf("failed to reach the tracker:\n%s ", err.Error())
 	}

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -46,7 +46,7 @@ func (T *HttpTracker) SwapFirst(currentIdx int) {
 	T.Urls[currentIdx] = aux
 }
 
-func (T *HttpTracker) Announce(query string, headers map[string]string, retry bool, callBack func(int)) (*TrackerResponse, error) {
+func (T *HttpTracker) Announce(query string, headers map[string]string, retry bool, callBack func(newEstimatedTimeToAnnounce int)) (*TrackerResponse, error) {
 	defer func() {
 		T.RetryAttempt = 0
 	}()


### PR DESCRIPTION
My take on @jhuggart idea of removing the channel  
- removal of ioutill calls (go 1.16)
- callback instead of channel to update the estimated time to announce


The other way would be as you said to move the estimated-time to the tracker.go, but i feel like all the state management should be located on ratiospoof.go, and let the tracker.go do as little as possible, what do you think?




